### PR TITLE
Improve location capture and filtering

### DIFF
--- a/src/components/LocationPreviewModal.tsx
+++ b/src/components/LocationPreviewModal.tsx
@@ -69,11 +69,14 @@ const LocationPreviewModal = ({ location, onClose }) => {
         </div>
 
         {location.imageUrl && (
-          <div className="relative">
+          <div
+            className="relative w-full bg-gray-50 flex items-center justify-center"
+            style={{ aspectRatio: '16 / 9' }}
+          >
             <img
               src={location.imageUrl}
               alt={location.name}
-              className="w-full h-64 object-cover"
+              className="max-h-full max-w-full object-contain"
             />
             {location.imageSource === 'google' && location.imageContext && (
               <a


### PR DESCRIPTION
## Summary
- normalize selected locations to capture city and district data and remove the explicit city requirement when creating activities
- add an ilçe dropdown filter alongside the existing city and sport filters and allow searching by city names
- present location photos inside a centered 16:9 frame in both the create form and previews to avoid distortion

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68e535c2a1248323a6081a18d5ee7a57